### PR TITLE
Remove 'reboot' step from the installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ The default configuration file is `config.xml`, stored in the same directory as 
 	[Install]  
 	WantedBy=multi-user.target   
 
-2. Enable service `systemctl enable airupnp.service`
+2. Enable the service `systemctl enable airupnp.service`
 
-3. Reboot
+3. Start the service `sudo service airupnp start`
 
 To start or stop manually the service, type `sudo service airupnp start|stop` in a command line window
 


### PR DESCRIPTION
A reboot is not necessary, as verified on a couple of Raspberry Pi devices running Stretch. The service just needs to be started.