### PR TITLE
Improve detection against rm -r /

### DIFF
--- a/updater
+++ b/updater
@@ -20,6 +20,19 @@ if test -f "airupnp.service";
         mode=Installing
         echo "First Installation detected."
         read -p "Enter full path where to install: "  currdirectory
+
+        if test -z "$currdirectory"
+        then
+            # install to current path if nothing is entered
+            currdirectory=$PWD
+        fi
+
+        if [ "$currdirectory" = "/" ];
+        then
+            echo "Can't install at root"
+            exit 1
+        fi
+
         mkdir $currdirectory
 fi
 tmpfolder=/tmp/AirConnect


### PR DESCRIPTION
I accidentally nuked my Raspberry Pi trying to install AirConnect with the update script

When the script prompted me for the installation path I just pressed enter and then the script deleted all my files at line 66:

`
rm -r $currdirectory/*
`

With variable $currdirectory empty

I added some validation logic. If no path is entered, then the current path is used. Then if the path is root, then the script stops
