### PR TITLE
Fix airupnp speaker renaming issue

### DIFF
--- a/airupnp/src/airupnp.c
+++ b/airupnp/src/airupnp.c
@@ -765,9 +765,9 @@ static void *UpdateThread(void *args)
 							!strncmp(Device->friendlyName, Device->Config.Name, strlen(Device->friendlyName)) &&
 							Device->Config.Name[strlen(Device->Config.Name) - 1] == '+') {
 							LOG_INFO("[%p]: Device name change %s %s", Device, friendlyName, Device->friendlyName);
-							raop_update(Device->Raop, friendlyName, "airupnp");
 							strcpy(Device->friendlyName, friendlyName);
 							sprintf(Device->Config.Name, "%s+", friendlyName);
+							raop_update(Device->Raop, Device->Config.Name, "airupnp");
 						}
 
 						// we are a master (or not a Sonos)


### PR DESCRIPTION
This fixes an issue where a speaker loses the '+' suffix to its airupnp name on a rename event (or on other events interpreted as renames). This is the issue reported in #196.