### PR TITLE
airupnp: search for mediarenderer:3 (fixes #90)

### DIFF
--- a/airupnp/src/airupnp.c
+++ b/airupnp/src/airupnp.c
@@ -1139,6 +1139,7 @@ static bool Start(bool cold)
 
 		UpnpSearchAsync(glControlPointHandle, DISCOVERY_TIME, MEDIA_RENDERER ":1", NULL);
 		UpnpSearchAsync(glControlPointHandle, DISCOVERY_TIME, MEDIA_RENDERER ":2", NULL);
+		UpnpSearchAsync(glControlPointHandle, DISCOVERY_TIME, MEDIA_RENDERER ":3", NULL);
 	}
 
 	return true;


### PR DESCRIPTION
This commit adds support for mediarenderer:3 which is used by my AndroidTV (Philips 43PUS6501/12), see #90.