### PR TITLE
airupnp.c: add missing newline to usage

### DIFF
--- a/airupnp/src/airupnp.c
+++ b/airupnp/src/airupnp.c
@@ -151,7 +151,7 @@ static char usage[] =
 		   "Usage: [options]\n"
 		   "  -b <server>[:<port>]\tnetwork interface and UPnP port to use \n"
 		   "  -c <mp3[:<rate>]|flc[:0..9]|wav|pcm>\taudio format send to player\n"
-		   "  -u <version>\tset the maximum UPnP version for search (default 1)"
+		   "  -u <version>\tset the maximum UPnP version for search (default 1)\n"
 		   "  -x <config file>\tread config from file (default is ./config.xml)\n"
 		   "  -i <config file>\tdiscover players, save <config file> and exit\n"
 		   "  -I \t\t\tauto save config at every network scan\n"


### PR DESCRIPTION
Hey! It looks like there was a newline omitted in the usage that should be there.

I ran `airupnp-x86-64-static -h` and saw that the new `-u` flag line didn't terminate with a newline:

<img width="1439" alt="Screen Shot 2020-11-24 at 11 13 27 PM" src="https://user-images.githubusercontent.com/237985/100182461-ac010c80-2eaa-11eb-88a8-d796e518c147.png">
